### PR TITLE
Add namespace option to split reducers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# CHANGELOG
+
+## 1.2.0 (2018-03-31)
+
+#2 Add optional name param in createCirquitAction
+
+## 1.1.0 (2018-03-27)
+
+First release

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# redux-cirquit [![Build Status](https://travis-ci.com/airtoxin/redux-cirquit.svg?token=PRvi8x3pzXzuck3j3Jmt&branch=master)](https://travis-ci.com/airtoxin/redux-cirquit)
+# redux-cirquit [![Build Status](https://travis-ci.org/airtoxin/redux-cirquit.svg?branch=master)](https://travis-ci.org/airtoxin/redux-cirquit)
 
 __Realize command based short-circuiting redux.__
 

--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ store.dispatch(increment(1)); // state is { counter: { count: 1 } }
 
 ## API
 
-### export createCirquitReducer<State>(initialState: State): Redux.Reducer<State>
+### export createCirquitReducer<State>(initialState: State, options?: { namespace?: string }): Redux.Reducer<State>
 
 Creates redux-cirquit's reducer that manages your application's state.
 
-### export createCirquitAction<State>(reducer: State => State, name?: string): Redux.Action
+### export createCirquitAction<State>(reducer: State => State, options?: { name?: string, namespace?: string }): Redux.Action
 
 Creates basic redux action to reduce you application's state.
 If this invoked with optional `name` argument or

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ with combineReducers
 
 ```js
 const store = createStore(combineReducers({
-  counter: createCirquitReducer(initialCounterState, { namespace: 'counter' }),
-  user: createCirquitReducer(initialUserState, { namespace: 'user' })
+  counter: createCirquitReducer(initialCounterState, { namespace: "counter" }),
+  user: createCirquitReducer(initialUserState, { namespace: "user" })
 }));
 
 const increment = amount => createCirquitAction(state => ({

--- a/README.md
+++ b/README.md
@@ -60,20 +60,38 @@ const increment = amount => createCirquitAction(state => ({
 store.dispatch(increment(1)); // state is { counter: { count: 1 } }
 ```
 
+with combineReducers
+
+```js
+const store = createStore(combineReducers({
+  counter: createCirquitReducer(initialCounterState, { namespace: 'counter' }),
+  user: createCirquitReducer(initialUserState, { namespace: 'user' })
+}));
+
+const increment = amount => createCirquitAction(state => ({
+  ...state,
+  count: state.count + amount
+}), { namespace: "counter" });
+
+store.dispatch(increment(1));
+```
+
 [Full example](https://github.com/airtoxin/redux-cirquit-example)
 
 ## API
 
-### export createCirquitReducer<State>(initialState: State, options?: { namespace?: string }): Redux.Reducer<State>
+### export createCirquitReducer\<State\>(initialState: State, options?: { namespace?: string }): Redux.Reducer\<State\>
 
-Creates redux-cirquit's reducer that manages your application's state.
+Creates redux-cirquit's reducer that manages your application's state.  
+If you want to split reducer using `combineReducers`, you must specify reducer name by `namespace` option.
 
-### export createCirquitAction<State>(reducer: State => State, options?: { name?: string, namespace?: string }): Redux.Action
+### export createCirquitAction\<State\>(reducer: (state: State) => State, options?: { name?: string, namespace?: string }): Redux.Action
 
-Creates basic redux action to reduce you application's state.
-If this invoked with optional `name` argument or
-reducer in arguments has [function name](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name),
-this function returns redux action that has its name parameter. Otherwise action.name set "anonymous".
+Creates basic redux action to reduce you application's state.  
+If you use splited reducer, must set same `namespace` option of related reducer to this action.  
+`name` is optional argument to define action name.
+If not specify `name`, [function name](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name) or "anonymous" is used.
+This option is used to debugging only.
 
 ## License
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -15,11 +15,22 @@ const initialState: State = {
 
 const noopReducer: cirquit.CirquitReducer<State> = state => state;
 
-const incrementAction = cirquit.createCirquitAction<State>(state => ({
-  counter: {
-    count: state.counter.count + 1
-  }
-}));
+const incrementActionWithoutNamespace = cirquit.createCirquitAction<State>(
+  state => ({
+    counter: {
+      count: state.counter.count + 1
+    }
+  })
+);
+
+const incrementActionWithNamespace = cirquit.createCirquitAction<State>(
+  state => ({
+    counter: {
+      count: state.counter.count + 1
+    }
+  }),
+  { namespace: "my-namespace" }
+);
 
 describe("createCirquitAction", () => {
   it("should return cirquitAction", () => {
@@ -30,7 +41,7 @@ describe("createCirquitAction", () => {
     });
   });
 
-  describe("cirquitAction name", () => {
+  describe("name option", () => {
     it("should be anonymous when reducer is arrow function", () => {
       expect(cirquit.createCirquitAction(state => state).name).toBe(
         "anonymous"
@@ -67,20 +78,67 @@ describe("createCirquitAction", () => {
       ).toBe("nameParams");
     });
   });
+
+  describe("namespace option", () => {
+    it("should be namespace defined action when specified namespace option", () => {
+      expect(
+        cirquit.createCirquitAction(noopReducer, { namespace: "my-namespace" })
+          .type
+      ).toBe("@@cirquit/action/my-namespace");
+    });
+  });
 });
 
 describe("createCirquitReducer's reducer", () => {
-  const reducer = cirquit.createCirquitReducer(initialState);
-
   it("should return initialState when invoke with @@init action", () => {
+    const reducer = cirquit.createCirquitReducer(initialState);
     expect(reducer(undefined, { type: "@@init" } as any)).toEqual(initialState);
   });
 
   it("should return reduced state when invoke with cirquitAction", () => {
-    expect(reducer(initialState, incrementAction)).toEqual({
+    const reducer = cirquit.createCirquitReducer(initialState);
+    expect(reducer(initialState, incrementActionWithoutNamespace)).toEqual({
       counter: {
         count: 1
       }
+    });
+  });
+
+  describe("namespace option", () => {
+    it("should react when action and reducer has same namespace", () => {
+      const reducer = cirquit.createCirquitReducer(initialState, {
+        namespace: "my-namespace"
+      });
+      expect(reducer(initialState, incrementActionWithNamespace)).toEqual({
+        counter: {
+          count: 1
+        }
+      });
+    });
+
+    it("should not react when action and reducer has different namespace", () => {
+      const reducer = cirquit.createCirquitReducer(initialState, {
+        namespace: "another-namespace"
+      });
+      expect(reducer(initialState, incrementActionWithNamespace)).toEqual(
+        initialState
+      );
+    });
+
+    it("should not react when action has namespace, reducer has not namespace", () => {
+      const reducer = cirquit.createCirquitReducer(initialState);
+      expect(reducer(initialState, incrementActionWithNamespace)).toEqual(
+        initialState
+      );
+    });
+
+    it("should not react when action has not namespace, reducer has namespace", () => {
+      const reducer = cirquit.createCirquitReducer(initialState, {
+        namespace: "my-namespace"
+      });
+      expect(reducer(initialState, incrementActionWithoutNamespace)).toEqual(
+        initialState
+      );
     });
   });
 });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -24,7 +24,7 @@ const incrementAction = cirquit.createCirquitAction<State>(state => ({
 describe("createCirquitAction", () => {
   it("should return cirquitAction", () => {
     expect(cirquit.createCirquitAction(noopReducer)).toEqual({
-      type: cirquit.CirquitActionType,
+      type: cirquit.getCirquitActionType(),
       name: "noopReducer",
       reducer: noopReducer
     });
@@ -60,11 +60,11 @@ describe("createCirquitAction", () => {
       ).toBe("namedReducer");
     });
 
-    it("should named when invoked with name argument", () => {
+    it("should named when invoked with name option", () => {
       const namedReducer = (state: State) => state;
-      expect(cirquit.createCirquitAction(namedReducer, "nameParams").name).toBe(
-        "nameParams"
-      );
+      expect(
+        cirquit.createCirquitAction(namedReducer, { name: "nameParams" }).name
+      ).toBe("nameParams");
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,7 @@
 import { Action } from "redux";
 
-export const CirquitActionType = "@cirquit/action";
-
 export const getCirquitActionType = (namespace: string = "") =>
-  `${CirquitActionType}@@${namespace}`;
+  `@@cirquit/action/${namespace}`;
 
 export interface CirquitReducer<State> {
   (state: State): State;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,32 +2,44 @@ import { Action } from "redux";
 
 export const CirquitActionType = "@cirquit/action";
 
+export const getCirquitActionType = (namespace: string = "") =>
+  `${CirquitActionType}@@${namespace}`;
+
 export interface CirquitReducer<State> {
   (state: State): State;
   name?: string;
 }
 
 export interface CirquitAction<State> extends Action {
-  type: typeof CirquitActionType;
+  type: string;
   name: string;
   reducer: CirquitReducer<State>;
 }
 
+export interface CirquitActionOptions {
+  name?: string;
+  namespace?: string;
+}
+
 export const createCirquitAction = <State>(
   reducer: CirquitReducer<State>,
-  name?: string
+  options: CirquitActionOptions = {}
 ): CirquitAction<State> => ({
-  type: CirquitActionType,
-  name: name || reducer.name || "anonymous",
+  type: getCirquitActionType(options.namespace),
+  name: options.name || reducer.name || "anonymous",
   reducer
 });
 
-export const createCirquitReducer = <State>(initialState: State) => (
-  state: State = initialState,
-  action: CirquitAction<State>
-): State => {
+export interface CirquitReducerOptions {
+  namespace?: string;
+}
+
+export const createCirquitReducer = <State>(
+  initialState: State,
+  options: CirquitReducerOptions = {}
+) => (state: State = initialState, action: CirquitAction<State>): State => {
   switch (action.type) {
-    case CirquitActionType: {
+    case getCirquitActionType(options.namespace): {
       return action.reducer(state);
     }
     default: {


### PR DESCRIPTION
namespace is used for "which reducer was invoked by this action?"
